### PR TITLE
Fix the token expired issue

### DIFF
--- a/TA-lansweeper-add-on-for-splunk/README.md
+++ b/TA-lansweeper-add-on-for-splunk/README.md
@@ -153,7 +153,7 @@ To uninstall app, user can follow below steps:
 RELEASE NOTES
 -------------
 Version 1.3.2 (Oct 2023)
-* Fixed the token expired issue.
+* Fixed the token expired issue (Account reconfiguration is required to resume the data collection).
     * What was the issue?: The access token was not getting renewed because the Lansweeper API now returns 401 status code when token is not valid. Earlier it was returning 400 status code.
 
 Version 1.3.1 (Sep 2022)

--- a/TA-lansweeper-add-on-for-splunk/README.md
+++ b/TA-lansweeper-add-on-for-splunk/README.md
@@ -152,6 +152,10 @@ To uninstall app, user can follow below steps:
 
 RELEASE NOTES
 -------------
+Version 1.3.2 (Oct 2023)
+* Fixed the token expired issue.
+    * What was the issue?: The access token was not getting renewed because the Lansweeper API now returns 401 status code when token is not valid. Earlier it was returning 400 status code.
+
 Version 1.3.1 (Sep 2022)
 * Handled the Lansweeper API issue.
     * What was the issue?: As recently noticed (Sep 2022) Lansweeper API removed the field "_id" from the API response. The Lansweeper API Document still does not mention anything about this change on it.

--- a/TA-lansweeper-add-on-for-splunk/README.md
+++ b/TA-lansweeper-add-on-for-splunk/README.md
@@ -153,8 +153,9 @@ To uninstall app, user can follow below steps:
 RELEASE NOTES
 -------------
 Version 1.3.2 (Oct 2023)
-* Fixed the token expired issue (Account reconfiguration is required to resume the data collection).
+* Fixed the token expired issue
     * What was the issue?: The access token was not getting renewed because the Lansweeper API now returns 401 status code when token is not valid. Earlier it was returning 400 status code.
+    *  Account reconfiguration is required only if the data collection does not auto resume after addon upgrade.
 
 Version 1.3.1 (Sep 2022)
 * Handled the Lansweeper API issue.

--- a/TA-lansweeper-add-on-for-splunk/app.manifest
+++ b/TA-lansweeper-add-on-for-splunk/app.manifest
@@ -19,7 +19,7 @@
         "id": {
             "group": null,
             "name": "TA-lansweeper-add-on-for-splunk",
-            "version": "1.3.1"
+            "version": "1.3.2"
         },
         "license": {
             "name": null,

--- a/TA-lansweeper-add-on-for-splunk/appserver/static/js/build/globalConfig.json
+++ b/TA-lansweeper-add-on-for-splunk/appserver/static/js/build/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "TA-lansweeper-add-on-for-splunk",
         "displayName": "Lansweeper Add-on for Splunk",
-        "version": "1.3.1",
+        "version": "1.3.2",
         "restRoot": "TA_lansweeper_add_on_for_splunk",
         "schemaVersion": "0.0.3"
     },

--- a/TA-lansweeper-add-on-for-splunk/bin/ta_lansweeper_api.py
+++ b/TA-lansweeper-add-on-for-splunk/bin/ta_lansweeper_api.py
@@ -116,7 +116,7 @@ class Lansweeper:
             response = json.loads(response)
             self.logger.info('Checking if the access token is expired')
 
-            if status_code == 400:
+            if status_code == 400 or status_code == 401:
             #  and ((response.get('errors', [])[0].get('extensions', {}).get('code') == 'UNAUTHENTICATED') or (response.get('errors', [])[0].get('extensions', {}).get('extensions', {}).get('code') == 'UNAUTHENTICATED')):
                 self.logger.info(
                     'Access token is expired. Calling the refresh token API')
@@ -132,7 +132,7 @@ class Lansweeper:
                 # self.logger.debug("access_token: {}".format(response.get('access_token')))
                 return {'access_token': response.get('access_token')}
             else:
-                self.logger.warning("Non 400 status code. status_code={}, response={}".format(status_code, response))
+                self.logger.warning("Non 400/401 status code. status_code={}, response={}".format(status_code, response))
         except Exception as exception:
             self.logger.exception(
                 'Error while checking if the access token is expired, error={}'.format(exception))

--- a/TA-lansweeper-add-on-for-splunk/default/app.conf
+++ b/TA-lansweeper-add-on-for-splunk/default/app.conf
@@ -6,7 +6,7 @@ build = 1
 [launcher]
 author = Crossrealms International Inc.
 description = The Lansweeper Add-on for Splunk is an Splunk App that allows user to collect information (assets) from Lansweeper Cloud into Splunk.
-version = 1.3.1
+version = 1.3.2
 
 [ui]
 is_visible = true


### PR DESCRIPTION
The lansweeper API now returns 401 if token is expired.